### PR TITLE
Fix Build Error with Publish v0.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 
 // TidyHTMLPublishStep
 // © 2020 John Mueller
@@ -8,6 +8,7 @@ import PackageDescription
 
 let package = Package(
     name: "TidyHTMLPublishStep",
+    platforms: [.macOS(.v12)],
     products: [
         .library(name: "TidyHTMLPublishStep", targets: ["TidyHTMLPublishStep"]),
     ],


### PR DESCRIPTION
Bumps `swift-tools-version` to `5.5` and requires macOS 12.0.

Publish [0.9.0](https://github.com/JohnSundell/Publish/releases/tag/0.9.0) requires Swift 5.5 and macOS 12.0 Monterey. Attempting to build a package using the latest version of Publish and this plugin fails with the following error:

```
The package product 'Publish' requires minimum platform version 12.0 for the macOS platform, but this target supports 10.13
```

This change fixes that.